### PR TITLE
Add v8 nodeinfo command to print out basic information about the node…

### DIFF
--- a/src/llnode.cc
+++ b/src/llnode.cc
@@ -311,6 +311,11 @@ bool PluginInitialize(SBDebugger d) {
   interpreter.AddCommand("findjsinstances", new llnode::FindInstancesCmd(),
                          "List all objects which share the specified map.\n");
 
+  v8.AddCommand("nodeinfo", new llnode::NodeInfoCmd(),
+                "Print information about Node.js\n");
+
+  interpreter.AddCommand("nodeinfo", new llnode::NodeInfoCmd(),
+                         "Print information about Node.js\n");
 
   return true;
 }

--- a/src/llscan.h
+++ b/src/llscan.h
@@ -26,6 +26,14 @@ class FindInstancesCmd : public CommandBase {
   bool detailed_;
 };
 
+class NodeInfoCmd : public CommandBase {
+ public:
+  ~NodeInfoCmd() override{};
+
+  bool DoExecute(lldb::SBDebugger d, char** cmd,
+                 lldb::SBCommandReturnObject& result) override;
+};
+
 class MemoryVisitor {
  public:
   virtual ~MemoryVisitor(){};

--- a/src/llv8.h
+++ b/src/llv8.h
@@ -232,13 +232,23 @@ class JSObject : public HeapObject {
   std::string Inspect(InspectOptions* options, Error& err);
   std::string InspectProperties(Error& err);
 
- protected:
-  template <class T>
-  T GetInObjectValue(int64_t size, int index, Error& err);
-
   std::string InspectElements(Error& err);
   std::string InspectDictionary(Error& err);
   std::string InspectDescriptors(Map map, Error& err);
+  void Keys(std::vector<std::string>& keys, Error& err);
+  Value GetProperty(std::string key_name, Error& err);
+  int64_t GetArrayLength(Error& err);
+  Value GetArrayElement(int64_t pos, Error& err);
+
+
+ protected:
+  template <class T>
+  T GetInObjectValue(int64_t size, int index, Error& err);
+  void ElementKeys(std::vector<std::string>& keys, Error& err);
+  void DictionaryKeys(std::vector<std::string>& keys, Error& err);
+  void DescriptorKeys(std::vector<std::string>& keys, Map map, Error& err);
+  Value GetDictionaryProperty(std::string key_name, Error& err);
+  Value GetDescriptorProperty(std::string key_name, Map map, Error& err);
 };
 
 class JSArray : public JSObject {


### PR DESCRIPTION
… process.

This change adds the nodeinfo command to llscan.cc/.h as it requires a heap scan before it can run. (The results of which are cached and shared with the existing findjsobject and findjsinstances commands.)

It adds accessor functions for retrieving the values of properties within JavaScript
objects to llv8.cc/.h rather than just formatting them as strings. This allows us to examine both the process object and navigate from it to objects referenced from its properties.
